### PR TITLE
Exllama q4 kernel

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -770,7 +770,11 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 
         model_save_name = resolved_archive_file
 
-        if not use_triton and trainable:
+        if not disable_exllama and trainable:
+            logger.warning("QuantLinear with exllama backend not support trainable mode yet, Switch to the pytorch backend.")
+            disable_exllama = True
+            
+        elif not use_triton and trainable:
             logger.warning("QuantLinear with cuda backend not support trainable mode yet, Switch to the pytorch backend.")
 
         # == step2: convert model to gptq-model (replace Linear with QuantLinear) == #

--- a/auto_gptq/nn_modules/fused_llama_attn.py
+++ b/auto_gptq/nn_modules/fused_llama_attn.py
@@ -2,50 +2,34 @@ import math
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
-from transformers.models.llama.modeling_llama import LlamaAttention, apply_rotary_pos_emb, repeat_kv
+from transformers.models.llama.modeling_llama import LlamaAttention, apply_rotary_pos_emb
 
 from ._fused_base import FusedBaseAttentionModule
 from ..utils.import_utils import compare_pytorch_version, dynamically_import_QuantLinear
+import inspect
 
 class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
     def __init__(
         self,
-        config,
+        hidden_size,
+        num_heads,
         qkv_proj,
         o_proj,
         rotary_emb,
     ):
         super().__init__()
-        self.config = config
-        self.hidden_size = config.hidden_size
-        self.num_heads = config.num_attention_heads
-        self.head_dim = self.hidden_size // self.num_heads
-        self.num_key_value_heads = config.num_key_value_heads
-        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
-        self.max_position_embeddings = config.max_position_embeddings
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
 
-        if (self.head_dim * self.num_heads) != self.hidden_size:
+        if self.head_dim * num_heads != self.hidden_size:
             raise ValueError(
                 f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
-                f" and `num_heads`: {self.num_heads})."
+                f" and `num_heads`: {num_heads})."
             )
-        if self.config.pretraining_tp > 1:
-            raise NotImplementedError(f"pretraining_tp of 2 or more is currently not supported.")
-            
-        if len(qkv_proj) == 1:
-            self.qkv_mode = 'qkv'
-            self.qkv_proj = qkv_proj[0]
-        elif len(qkv_proj) == 2:
-            self.qkv_mode = 'q,kv'
-            self.q_proj = qkv_proj[0]
-            self.kv_proj = qkv_proj[1]
-        else:
-            self.qkv_mode = 'q,k,v'
-            self.q_proj = qkv_proj[0]
-            self.k_proj = qkv_proj[1]
-            self.v_proj = qkv_proj[2]
+        self.qkv_proj = qkv_proj
         self.o_proj = o_proj
         self.rotary_emb = rotary_emb
 
@@ -55,9 +39,9 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
     def forward(
         self,
         hidden_states,
+        past_key_value=None,
         attention_mask=None,
         position_ids=None,
-        past_key_value=None,
         output_attentions=False,
         use_cache=False,
         **kwargs
@@ -65,22 +49,14 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
         """Input shape: Batch x Time x Channel"""
 
         bsz, q_len, _ = hidden_states.size()
-        
-        if self.qkv_mode == 'qkv':
-            qkv_states = self.qkv_proj(hidden_states)
-            query_states, key_states, value_states = torch.split(qkv_states, self.hidden_size, dim=2)
-        elif self.qkv_mode == 'q,kv':
-            query_states = self.q_proj(hidden_states)
-            kv_states = self.kv_proj(hidden_states)
-            key_states, value_states = torch.split(kv_states, self.hidden_size, dim=2)
-        else:
-            query_states = self.q_proj(hidden_states)
-            key_states = self.k_proj(hidden_states)
-            value_states = self.v_proj(hidden_states)
+
+        qkv_states = self.qkv_proj(hidden_states)
+        query_states, key_states, value_states = torch.split(qkv_states, self.hidden_size, dim=2)
+
         query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        
+        key_states = key_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+
         kv_seq_len = key_states.shape[-2]
         if past_key_value is not None:
             kv_seq_len += past_key_value[0].shape[-2]
@@ -103,10 +79,6 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
 
         past_key_value = (key_states, value_states) if use_cache else None
 
-        # repeat k/v heads if n_kv_heads < n_heads
-        key_states = repeat_kv(key_states, self.num_key_value_groups)
-        value_states = repeat_kv(value_states, self.num_key_value_groups)
-        
         if compare_pytorch_version("v2.0.0", op="eq"):
             attn_output = F.scaled_dot_product_attention(
                 query_states,
@@ -121,7 +93,7 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
 
             if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
                 raise ValueError(
-                    f"Attention weights should be of size {(bsz, self.num_heads, q_len, kv_seq_len)}, but is"
+                    f"Attention weights should be of size {(bsz * self.num_heads, q_len, kv_seq_len)}, but is"
                     f" {attn_weights.size()}"
                 )
 
@@ -131,6 +103,7 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
                         f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
                     )
                 attn_weights = attn_weights + attention_mask
+                attn_weights = torch.max(attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min))
 
             # upcast attention to fp32
             attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
@@ -177,63 +150,41 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
             k_proj = m.k_proj
             v_proj = m.v_proj
 
-            if QuantLinear.QUANT_TYPE == "exllama" and desc_act:
-                qkv_layers = [q_proj,k_proj,v_proj]
-            elif m.num_heads == m.num_key_value_heads:
-                qweights = torch.cat([q_proj.qweight, k_proj.qweight, v_proj.qweight], dim=1)
-                qzeros = torch.cat([q_proj.qzeros, k_proj.qzeros, v_proj.qzeros], dim=1)
-                scales = torch.cat([q_proj.scales, k_proj.scales, v_proj.scales], dim=1)
-                if QuantLinear.QUANT_TYPE == "exllama":
-                    g_idx = None
-                else:
-                    g_idx = torch.cat([q_proj.g_idx, k_proj.g_idx, v_proj.g_idx], dim=0)
-                bias = torch.cat([q_proj.bias, k_proj.bias, v_proj.bias], dim=0) if q_proj.bias is not None else None
+            qweights = torch.cat([q_proj.qweight, k_proj.qweight, v_proj.qweight], dim=1)
+            qzeros = torch.cat([q_proj.qzeros, k_proj.qzeros, v_proj.qzeros], dim=1)
+            scales = torch.cat([q_proj.scales, k_proj.scales, v_proj.scales], dim=1)
 
-                qlinear_args = (
-                    q_proj.bits,
-                    q_proj.group_size,
-                    q_proj.infeatures,
-                    q_proj.outfeatures + k_proj.outfeatures + v_proj.outfeatures,
-                    True if q_proj.bias is not None else False,
-                )
-                qlinear_kwargs = {"trainable": trainable}
-                if (not desc_act or group_size == -1) and not use_triton:
-                    qlinear_kwargs["use_cuda_fp16"] = use_cuda_fp16
-                qkv_layer = QuantLinear(*qlinear_args, **qlinear_kwargs)
-                qkv_layer.qweight = qweights
-                qkv_layer.qzeros = qzeros
-                qkv_layer.scales = scales
-                qkv_layer.g_idx = g_idx
-                qkv_layer.bias = bias
-                qkv_layers = [qkv_layer]
+            if QuantLinear.QUANT_TYPE == "exllama":
+                if desc_act:
+                    # TODO: support it. The issue lies maybe in the line:
+                    # int groups = qzeros.size(0);
+                    # in exllama_ext.cpp
+                    raise ValueError("Exllama kernel does not support query/key/value fusion with act-order. Please either use inject_fused_attention=False or disable_exllama=True.")
+                else:
+                    g_idx = None
             else:
-                qweights = torch.cat([k_proj.qweight, v_proj.qweight], dim=1)
-                qzeros = torch.cat([k_proj.qzeros, v_proj.qzeros], dim=1)
-                scales = torch.cat([k_proj.scales, v_proj.scales], dim=1)
-                if QuantLinear.QUANT_TYPE == "exllama":
-                    g_idx = None
-                else:
-                    g_idx = torch.cat([k_proj.g_idx, v_proj.g_idx], dim=0)
-                bias = torch.cat([k_proj.bias, v_proj.bias], dim=0) if q_proj.bias is not None else None
+                g_idx = torch.cat([q_proj.g_idx, k_proj.g_idx, v_proj.g_idx], dim=0)
+            
+            bias = torch.cat([q_proj.bias, k_proj.bias, v_proj.bias], dim=0) if q_proj.bias is not None else None
 
-                qlinear_args = (
-                    k_proj.bits,
-                    k_proj.group_size,
-                    k_proj.infeatures,
-                    k_proj.outfeatures + v_proj.outfeatures,
-                    True if q_proj.bias is not None else False,
-                )
-                qlinear_kwargs = {"trainable": trainable}
-                if (not desc_act or group_size == -1) and not use_triton:
-                    qlinear_kwargs["use_cuda_fp16"] = use_cuda_fp16
-                kv_layer = QuantLinear(*qlinear_args, **qlinear_kwargs)
-                kv_layer.qweight = qweights
-                kv_layer.qzeros = qzeros
-                kv_layer.scales = scales
-                kv_layer.g_idx = g_idx
-                kv_layer.bias = bias
-                qkv_layers = [q_proj, kv_layer]
-            attn = cls(m.config, qkv_layers, m.o_proj, m.rotary_emb)
+            qlinear_args = (
+                q_proj.bits,
+                q_proj.group_size,
+                q_proj.infeatures,
+                q_proj.outfeatures + k_proj.outfeatures + v_proj.outfeatures,
+                True if q_proj.bias is not None else False,
+            )
+            qlinear_kwargs = {"trainable": trainable}
+            if (not desc_act or group_size == -1) and not use_triton:
+                qlinear_kwargs["use_cuda_fp16"] = use_cuda_fp16
+            qkv_layer = QuantLinear(*qlinear_args, **qlinear_kwargs)
+            qkv_layer.qweight = qweights
+            qkv_layer.qzeros = qzeros
+            qkv_layer.scales = scales
+            qkv_layer.g_idx = g_idx
+            qkv_layer.bias = bias
+
+            attn = cls(m.hidden_size, m.num_heads, qkv_layer, m.o_proj, m.rotary_emb)
 
             if '.' in name:
                 parent_name = name.rsplit('.', 1)[0]
@@ -245,5 +196,6 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
                 child_name = name
 
             setattr(parent, child_name, attn)
+
 
 __all__ = ["FusedLlamaAttentionForQuantizedModel"]

--- a/auto_gptq/nn_modules/qlinear/qlinear_exllama.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_exllama.py
@@ -4,6 +4,8 @@ from exllama_kernels import make_q4, q4_matmul
 import torch
 import torch.nn as nn
 import math
+import numpy as np
+import transformers
 
 # Dummy tensor to pass instead of g_idx since there is no way to pass "None" to a C++ extension
 none_tensor = torch.empty((1, 1), device = "meta")
@@ -43,6 +45,8 @@ class QuantLinear(nn.Module):
         super().__init__()
         if bits != 4:
             raise ValueError(f"Exllama kernel supports only bits=4, requested bits={bits}. Something is wrong in the model initialization.")
+        if trainable:
+            raise NotImplementedError("Exllama kernel does not support training.")
         
         self.infeatures = infeatures
         self.outfeatures = outfeatures
@@ -93,10 +97,107 @@ class QuantLinear(nn.Module):
         )
 
     def pack(self, linear, scales, zeros, g_idx=None):
-        raise NotImplementedError("Pack is not supported for the exllama implementation. Please open an issue.")
+        W = linear.weight.data.clone()
+        if isinstance(linear, nn.Conv2d):
+            W = W.flatten(1)
+        if isinstance(linear, transformers.pytorch_utils.Conv1D):
+            W = W.t()
+
+        self.g_idx = g_idx.clone() if g_idx is not None else self.g_idx
+
+        scales = scales.t().contiguous()
+        zeros = zeros.t().contiguous()
+        scale_zeros = zeros * scales
+        self.scales = scales.clone().half()
+        if linear.bias is not None:
+            self.bias = linear.bias.clone().half()
+
+        intweight = []
+        for idx in range(self.infeatures):
+            intweight.append(
+                torch.round(
+                    (
+                        W[:, idx] + scale_zeros[self.g_idx[idx]]) / self.scales[self.g_idx[idx]]
+                ).to(torch.int)[:, None]
+            )
+        intweight = torch.cat(intweight, dim=1)
+        intweight = intweight.t().contiguous()
+        intweight = intweight.numpy().astype(np.uint32)
+
+        i = 0
+        row = 0
+        qweight = np.zeros(
+            (intweight.shape[0] // 32 * self.bits, intweight.shape[1]), dtype=np.uint32
+        )
+        while row < qweight.shape[0]:
+            if self.bits in [2, 4, 8]:
+                for j in range(i, i + (32 // self.bits)):
+                    qweight[row] |= intweight[j] << (self.bits * (j - i))
+                i += 32 // self.bits
+                row += 1
+            elif self.bits == 3:
+                for j in range(i, i + 10):
+                    qweight[row] |= intweight[j] << (3 * (j - i))
+                i += 10
+                qweight[row] |= intweight[i] << 30
+                row += 1
+                qweight[row] |= (intweight[i] >> 2) & 1
+                i += 1
+                for j in range(i, i + 10):
+                    qweight[row] |= intweight[j] << (3 * (j - i) + 1)
+                i += 10
+                qweight[row] |= intweight[i] << 31
+                row += 1
+                qweight[row] |= (intweight[i] >> 1) & 0x3
+                i += 1
+                for j in range(i, i + 10):
+                    qweight[row] |= intweight[j] << (3 * (j - i) + 2)
+                i += 10
+                row += 1
+            else:
+                raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+
+        qweight = qweight.astype(np.int32)
+        self.qweight = torch.from_numpy(qweight)
+
+        zeros -= 1
+        zeros = zeros.numpy().astype(np.uint32)
+        qzeros = np.zeros((zeros.shape[0], zeros.shape[1] // 32 * self.bits), dtype=np.uint32)
+        i = 0
+        col = 0
+        while col < qzeros.shape[1]:
+            if self.bits in [2, 4, 8]:
+                for j in range(i, i + (32 // self.bits)):
+                    qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
+                i += 32 // self.bits
+                col += 1
+            elif self.bits == 3:
+                for j in range(i, i + 10):
+                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i))
+                i += 10
+                qzeros[:, col] |= zeros[:, i] << 30
+                col += 1
+                qzeros[:, col] |= (zeros[:, i] >> 2) & 1
+                i += 1
+                for j in range(i, i + 10):
+                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 1)
+                i += 10
+                qzeros[:, col] |= zeros[:, i] << 31
+                col += 1
+                qzeros[:, col] |= (zeros[:, i] >> 1) & 0x3
+                i += 1
+                for j in range(i, i + 10):
+                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 2)
+                i += 10
+                col += 1
+            else:
+                raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+
+        qzeros = qzeros.astype(np.int32)
+        self.qzeros = torch.from_numpy(qzeros)
 
     def forward(self, x):
-        out = ext_q4_matmul(x, self.q4, self.width)
+        out = ext_q4_matmul(x.half(), self.q4, self.width)
 
         if self.bias is not None:
             out.add_(self.bias)

--- a/auto_gptq/nn_modules/qlinear/qlinear_exllama.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_exllama.py
@@ -130,32 +130,13 @@ class QuantLinear(nn.Module):
             (intweight.shape[0] // 32 * self.bits, intweight.shape[1]), dtype=np.uint32
         )
         while row < qweight.shape[0]:
-            if self.bits in [2, 4, 8]:
+            if self.bits in [4]:
                 for j in range(i, i + (32 // self.bits)):
                     qweight[row] |= intweight[j] << (self.bits * (j - i))
                 i += 32 // self.bits
                 row += 1
-            elif self.bits == 3:
-                for j in range(i, i + 10):
-                    qweight[row] |= intweight[j] << (3 * (j - i))
-                i += 10
-                qweight[row] |= intweight[i] << 30
-                row += 1
-                qweight[row] |= (intweight[i] >> 2) & 1
-                i += 1
-                for j in range(i, i + 10):
-                    qweight[row] |= intweight[j] << (3 * (j - i) + 1)
-                i += 10
-                qweight[row] |= intweight[i] << 31
-                row += 1
-                qweight[row] |= (intweight[i] >> 1) & 0x3
-                i += 1
-                for j in range(i, i + 10):
-                    qweight[row] |= intweight[j] << (3 * (j - i) + 2)
-                i += 10
-                row += 1
             else:
-                raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+                raise NotImplementedError("Only 4 bits are supported.")
 
         qweight = qweight.astype(np.int32)
         self.qweight = torch.from_numpy(qweight)
@@ -166,32 +147,13 @@ class QuantLinear(nn.Module):
         i = 0
         col = 0
         while col < qzeros.shape[1]:
-            if self.bits in [2, 4, 8]:
+            if self.bits in [4]:
                 for j in range(i, i + (32 // self.bits)):
                     qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
                 i += 32 // self.bits
                 col += 1
-            elif self.bits == 3:
-                for j in range(i, i + 10):
-                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i))
-                i += 10
-                qzeros[:, col] |= zeros[:, i] << 30
-                col += 1
-                qzeros[:, col] |= (zeros[:, i] >> 2) & 1
-                i += 1
-                for j in range(i, i + 10):
-                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 1)
-                i += 10
-                qzeros[:, col] |= zeros[:, i] << 31
-                col += 1
-                qzeros[:, col] |= (zeros[:, i] >> 1) & 0x3
-                i += 1
-                for j in range(i, i + 10):
-                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 2)
-                i += 10
-                col += 1
             else:
-                raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+                raise NotImplementedError("Only 4 bits are supported.")
 
         qzeros = qzeros.astype(np.int32)
         self.qzeros = torch.from_numpy(qzeros)


### PR DESCRIPTION
1. Add pack function (Follow cuda pack function.)
2. Since the input of exllama must be float16, it has been changed to automatically convert to float16.
3. exllama does not support backpropagation, so I changed to automatically disable when training.